### PR TITLE
Feature/debtors weight

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+from setuptools import setup
+
+setup(name='findus',
+      version='0.1',
+      description='Reduce debt graphs',
+      author='',
+      author_email='',
+      url='https://github.com/gapato/findus',
+      install_requires=['docopt', 'simplejson'],
+     )

--- a/test-weight.json
+++ b/test-weight.json
@@ -1,0 +1,20 @@
+[
+  {
+    "creditor": "A",
+    "amount": 10,
+    "debtors": [
+      {"name": "A", "weight": 3},
+      "B"
+    ],
+    "comment": "payment 1"
+  },
+  {
+    "creditor": "B",
+    "amount": 2,
+    "debtors": [
+      "A",
+      "B"
+    ],
+    "comment": "payment 2"
+  }
+]


### PR DESCRIPTION
Old syntax still working, now debtors array elements can also be an object with a name and a weight (default: 1).
